### PR TITLE
Fix read non-existed file in non-watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,25 @@
+# v1.3.1 (Jan 9, 2023)
+
+1. Fix read non-existed file in non-watch mode.
+
 # v1.3.0 (Jan 9, 2023)
 
-1.  Allow reading environment variables from file or os.
+1. Allow reading environment variables from file or os.
 
 # v1.2.0 (Jan 8, 2023)
 
-1.  Allow converting config to map.
+1. Allow converting config to map.
 
 # v1.1.1 (Jan 8, 2023)
 
-1.  Allow watching file even if the file didn't exist.
+1. Allow watching file even if the file didn't exist.
 
 # v1.1.0 (Jan 8, 2023)
 
-1.  Allow converting a value to time.Duration.
+1. Allow converting a value to time.Duration.
 
 # v1.0.0 (Jan 4, 2023)
 
-1.  Support json, ini format.
-2.  Reload config when the file changes.
-3.  Allow to hook change.
+1. Support json, ini format.
+2. Reload config when the file changes.
+3. Allow to hook change.

--- a/config_test.go
+++ b/config_test.go
@@ -188,6 +188,13 @@ func TestConfigReadFileNotExist(t *testing.T) {
 	xycond.ExpectError(err, xyconfig.ConfigError).Test(t)
 }
 
+func TestConfigReadFileNotExistWithWatching(t *testing.T) {
+	var cfg = xyconfig.GetConfig(t.Name())
+	var err = cfg.ReadFile("foo.json", true)
+
+	xycond.ExpectNil(err).Test(t)
+}
+
 func TestConfigReadFileWithChange(t *testing.T) {
 	ioutil.WriteFile(t.Name()+".json", []byte(`{"foo": "bar"}`), 0644)
 


### PR DESCRIPTION
#### Issue

-   Fix read non-existed file in non-watch mode

#### Changes

-   [x] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Checked README.md.
-   [x] Checked CHANGELOG.md
-   [x] Checked comments.
