### PR TITLE
Fix read non-existed directory in watching mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# v1.3.2 (Jan 11, 2023)
+
+1. Fix read non-existed directory in watching mode.
+
 # v1.3.1 (Jan 9, 2023)
 
-1. Fix read non-existed file in non-watch mode.
+1. Fix read non-existed file in non-watching mode.
 
 # v1.3.0 (Jan 9, 2023)
 
@@ -12,7 +16,7 @@
 
 # v1.1.1 (Jan 8, 2023)
 
-1. Allow watching file even if the file didn't exist.
+1.  Allow watching file even if the file didn't exist.
 
 # v1.1.0 (Jan 8, 2023)
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -505,6 +506,12 @@ func (c *Config) watchFile(filename string) error {
 	// exception.
 	var ferr error
 	if _, ferr = os.Open(filename); os.IsNotExist(ferr) {
+		var dir = filepath.Dir(filename)
+		fmt.Println(dir)
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return err
+		}
+
 		if _, err := os.OpenFile(filename, os.O_CREATE, 0666); err != nil {
 			return err
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -194,6 +194,12 @@ func TestConfigReadFileNotExistWithWatching(t *testing.T) {
 
 	xycond.ExpectNil(err).Test(t)
 }
+func TestConfigReadFileButDirNotExistWithWatching(t *testing.T) {
+	var cfg = xyconfig.GetConfig(t.Name())
+	var err = cfg.ReadFile("config/foo.json", true)
+
+	xycond.ExpectNil(err).Test(t)
+}
 
 func TestConfigReadFileWithChange(t *testing.T) {
 	ioutil.WriteFile(t.Name()+".json", []byte(`{"foo": "bar"}`), 0644)
@@ -219,7 +225,7 @@ func TestConfigLoadEnvWithChange(t *testing.T) {
 	xycond.ExpectEqual(cfg.MustGet("foo").MustString(), "bar").Test(t)
 
 	os.Setenv("foo", "buzz")
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	xycond.ExpectEqual(cfg.MustGet("foo").MustString(), "buzz").Test(t)
 }
 


### PR DESCRIPTION
#### Issue

-   Fix read non-existed directory in watching mode

#### Changes

-   [x] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Checked README.md.
-   [x] Checked CHANGELOG.md
-   [x] Checked comments.
