### PR TITLE
Remove redundant println command

### DIFF
--- a/config.go
+++ b/config.go
@@ -609,7 +609,6 @@ func (c *Config) watchFile(filename string) error {
 	var ferr error
 	if _, ferr = os.Open(filename); os.IsNotExist(ferr) {
 		var dir = filepath.Dir(filename)
-		fmt.Println(dir)
 		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 			return err
 		}


### PR DESCRIPTION
#### Issue

-   Remove redundant println command

#### Changes

-   [ ] Fix bug
-   [ ] New feature
-   [x] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Describe about your test.

#### Checklist

-   [ ] Checked README.md.
-   [ ] Checked CHANGELOG.md
-   [ ] Checked comments.
