### PR TITLE
String should be changed to array without brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.1 (Jan 24, 2023)
+
+1. String should be changed to array without brackets.
+
 # v1.4.0 (Jan 16, 2023)
 1. Support AWS S3.
 

--- a/value.go
+++ b/value.go
@@ -220,10 +220,6 @@ func (v Value) MustString() string {
 func (v Value) AsArray() ([]Value, bool) {
 	if s, ok := v.value.(string); ok && !v.strict {
 		s = strings.Trim(s, " ")
-		if s[0] != '[' || s[len(s)-1] != ']' {
-			return nil, false
-		}
-		s = s[1 : len(s)-1]
 		var elements []Value
 		for _, e := range strings.Split(s, ",") {
 			e = strings.Trim(e, " ")

--- a/value_test.go
+++ b/value_test.go
@@ -285,8 +285,8 @@ func TestValueAsString(t *testing.T) {
 func TestValueMustArray(t *testing.T) {
 	var cfg = xyconfig.GetConfig(t.Name())
 	cfg.Set("foo", []any{1, "foo"}, true)
-	cfg.Set("bar", `[1, foo]`, false)
-	cfg.Set("buzz", `[1, `, false)
+	cfg.Set("bar", `1, foo`, false)
+	cfg.Set("buzz", `1, `, false)
 
 	var array = cfg.MustGet("foo").MustArray()
 	xycond.ExpectEqual(array[0].MustInt(), 1).Test(t)
@@ -296,15 +296,16 @@ func TestValueMustArray(t *testing.T) {
 	xycond.ExpectEqual(array[0].MustInt(), 1).Test(t)
 	xycond.ExpectEqual(array[1].MustString(), "foo").Test(t)
 
-	xycond.ExpectPanic(xyconfig.CastError, func() { cfg.MustGet("buzz").MustArray() }).Test(t)
+	array = cfg.MustGet("buzz").MustArray()
+	xycond.ExpectEqual(array[0].MustInt(), 1).Test(t)
 }
 
 func TestValueAsArray(t *testing.T) {
 	var cfg = xyconfig.GetConfig(t.Name())
 	cfg.Set("foo", []any{1, "foo"}, true)
-	cfg.Set("bar", `[1, foo]`, false)
-	cfg.Set("buzz", `[1, `, true)
-	cfg.Set("bizz", `[1, `, false)
+	cfg.Set("bar", `1, foo`, false)
+	cfg.Set("buzz", `1, `, true)
+	cfg.Set("bizz", `1, `, false)
 
 	var array []xyconfig.Value
 	var ok bool
@@ -323,7 +324,8 @@ func TestValueAsArray(t *testing.T) {
 	xycond.ExpectFalse(ok).Test(t)
 
 	_, ok = cfg.MustGet("bizz").AsArray()
-	xycond.ExpectFalse(ok).Test(t)
+	xycond.ExpectTrue(ok).Test(t)
+	xycond.ExpectEqual(array[0].MustInt(), 1).Test(t)
 }
 
 func TestValueString(t *testing.T) {


### PR DESCRIPTION
#### Issue

-   Fix #17 
#### Changes

-   [x] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Checked README.md.
-   [x] Checked CHANGELOG.md
-   [ ] Checked comments.
